### PR TITLE
remove --only=production from RUN npm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV HOST 0.0.0.0
 
 COPY package*.json ./
 
-RUN npm install --only=production
+RUN npm install
 
 COPY . .
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,15 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c','docker build --no-cache -t gcr.io/$PROJECT_ID/testssr:$SHORT_SHA .']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['push','gcr.io/$PROJECT_ID/testssr:$SHORT_SHA']
+- name: 'gcr.io/cloud-builders/gcloud'
+  args:
+    - 'beta'
+    - 'run'
+    - 'deploy'
+    - 'testssr'
+    - '--image=gcr.io/$PROJECT_ID/testssr:$SHORT_SHA'
+    - '--region=us-central1'
+    - '--platform=managed'


### PR DESCRIPTION
To try out Solution/Answer from:
https://stackoverflow.com/questions/66127933/cloud-run-failed-to-start-and-then-listen-on-the-port-defined-by-the-port-envi